### PR TITLE
change slashes in CXX and CC environment variables

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -49,8 +49,8 @@ class MingwInstallerConan(ConanFile):
         self.env_info.path.append(os.path.join(self.package_folder, "bin"))
         self.env_info.MINGW_HOME = str(self.package_folder)
         self.env_info.CONAN_CMAKE_GENERATOR = "MinGW Makefiles"
-        self.env_info.CXX = os.path.join(self.package_folder, "bin", "g++.exe")
-        self.env_info.CC = os.path.join(self.package_folder, "bin", "gcc.exe")
+        self.env_info.CXX = os.path.join(self.package_folder, "bin", "g++.exe").replace("\\", "/")
+        self.env_info.CC = os.path.join(self.package_folder, "bin", "gcc.exe").replace("\\", "/")
 
 
 class Installer(namedtuple("Installer", "version arch threads exception revision url")):


### PR DESCRIPTION
before https://github.com/conan-io/conan/pull/3836 this change was performed by conan
since 1.9.0, conan does not change backward slashes into forward slashes. This leads to problems when using mingw32-make and sh.exe is in path, because sh.exe eats the backwards slashes