### PR TITLE
Do not use arch_build for MinGW installer

### DIFF
--- a/build.py
+++ b/build.py
@@ -4,7 +4,7 @@ import copy
 
 if __name__ == "__main__":
     builder = ConanMultiPackager()
-    base = {"os_build": "Windows", "compiler": "gcc", "compiler.version": "7",
+    base = {"os": "Windows", "compiler": "gcc", "compiler.version": "7",
             "compiler.exception": "seh", "compiler.libcxx": "libstdc++",
             "compiler.threads": "posix"}
     for version in ["4.9", "5", "6", "7", "8"]:
@@ -15,15 +15,13 @@ if __name__ == "__main__":
             tmp2["compiler.threads"] = th
             for ex in ["seh", "sjlj"]:
                 tmp3 = copy.copy(tmp2)
-                tmp3["arch_build"] = "x86_64"
                 tmp3["arch"] = "x86_64"
                 tmp3["compiler.exception"] = ex
                 builder.add(tmp3, {}, {}, {})
             for ex in ["dwarf2", "sjlj"]:
                 tmp3 = copy.copy(tmp2)
-                tmp3["arch_build"] = "x86"
                 tmp3["arch"] = "x86"
                 tmp3["compiler.exception"] = ex
                 builder.add(tmp3, {}, {}, {})
-
+    
     builder.run()

--- a/conanfile.py
+++ b/conanfile.py
@@ -11,10 +11,10 @@ class MingwInstallerConan(ConanFile):
     name = "mingw_installer"
     version = "1.0"
     license = "http://www.mingw.org/license"
-    url = "http://github.com/conan-community/conan-mingw-installer"
+    url = "http://github.com/lasote/conan-mingw-installer"
 
-    settings = {"os_build": ["Windows"],
-                "arch_build" : ["x86", "x86_64"],
+    settings = {"os": ["Windows"],
+                "arch" : ["x86", "x86_64"],
                 "compiler": {"gcc": {"version": None,
                                      "libcxx": ["libstdc++", "libstdc++11"],
                                      "threads": ["posix", "win32"],
@@ -29,7 +29,7 @@ class MingwInstallerConan(ConanFile):
     def build(self):
         self.output.info("Updating MinGW List ... please wait.")
 
-        installer = get_best_installer(str(self.settings.arch_build),
+        installer = get_best_installer(str(self.settings.arch),
                                        str(self.settings.compiler.threads),
                                        str(self.settings.compiler.exception),
                                        str(self.settings.compiler.version))
@@ -44,9 +44,6 @@ class MingwInstallerConan(ConanFile):
         self.copy("*", dst="", src="mingw64")
         shutil.rmtree('mingw32', True)
         shutil.rmtree('mingw64', True)
-
-    def package_id(self):
-        self.info.include_build_settings()
 
     def package_info(self):
         self.env_info.path.append(os.path.join(self.package_folder, "bin"))
@@ -73,7 +70,7 @@ def get_best_installer(arch, threads, exception, version):
 
     if arch == "x86":
         arch = "i686"
-
+        
     if exception == "dwarf2":
         exception = "dwarf"
 
@@ -131,28 +128,28 @@ if __name__ == "__main__":
     installer = get_best_installer("x86", "posix", "sjlj", "5.2.0")
     assert (installer.version == "5.2.0")
     assert (installer.revision == 1)
-
+    
     installer = get_best_installer("x86_64", "posix", "seh", "4.9")
     assert (installer.version == "4.9.4")
     assert (installer.revision == 0)
-
+    
     installer = get_best_installer("x86_64", "posix", "sjlj", "4.9")
     assert (installer.version == "4.9.4")
     assert (installer.revision == 0)
-
+    
     installer = get_best_installer("x86", "posix", "sjlj", "4.9")
     assert (installer.version == "4.9.4")
     assert (installer.revision == 0)
-
+    
     installer = get_best_installer("x86", "posix", "dwarf2", "4.9")
     assert (installer.version == "4.9.4")
     assert (installer.revision == 0)
-
+    
     installer = get_best_installer("x86_64", "posix", "seh", "6.3")
     assert (installer.version == "6.3.0")
     assert (installer.revision == 2)
-
+    
     installer = get_best_installer("x86_64", "posix", "seh", "7.1")
     assert (installer.version == "7.1.0")
     assert (installer.revision == 2)
-
+    


### PR DESCRIPTION
- Due last bugs related to CPT and MinGW builds, we gonna revert
  all changes which change its package id